### PR TITLE
chore: cleanup uuid naming internally for cleaner access e.g. pipelin…

### DIFF
--- a/sotai/constants.py
+++ b/sotai/constants.py
@@ -2,5 +2,4 @@
 
 MISSING_CATEGORY_VALUE = "<Missing Category>"
 MISSING_NUMERICAL_VALUE = float("-inf")
-# SOTAI_API_ENDPOINT = "https://app.sotai.ai"
-SOTAI_API_ENDPOINT = "http://localhost:5173"
+SOTAI_API_ENDPOINT = "https://app.sotai.ai"

--- a/sotai/constants.py
+++ b/sotai/constants.py
@@ -2,4 +2,5 @@
 
 MISSING_CATEGORY_VALUE = "<Missing Category>"
 MISSING_NUMERICAL_VALUE = float("-inf")
-SOTAI_API_ENDPOINT = "https://app.sotai.ai"
+# SOTAI_API_ENDPOINT = "https://app.sotai.ai"
+SOTAI_API_ENDPOINT = "http://localhost:5173"

--- a/sotai/pipeline.py
+++ b/sotai/pipeline.py
@@ -117,7 +117,7 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
         self.datasets: Dict[int, Dataset] = {}
 
         # Tracks
-        self.pipeline_uuid = None
+        self.uuid = None
 
     def prepare(  # pylint: disable=too-many-locals
         self,
@@ -275,8 +275,8 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
             Otherwise, None.
 
         """
-        self.pipeline_uuid = post_pipeline(self)
-        return self.pipeline_uuid
+        self.uuid = post_pipeline(self)
+        return self.uuid
 
     def analysis(self, trained_model: TrainedModel) -> Optional[str]:
         """Charts the results for the specified trained model in the SOTAI web client.
@@ -296,20 +296,20 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
                 " Please visit app.sotai.ai to get an API key."
             )
 
-        if self.pipeline_uuid is None:
-            self.pipeline_uuid = self.publish()
+        if self.uuid is None:
+            self.uuid = self.publish()
 
-        if self.pipeline_uuid is None:
+        if self.uuid is None:
             return None
 
         pipeline_config_uuid = post_pipeline_config(
-            self.pipeline_uuid, trained_model.pipeline_config
+            self.uuid, trained_model.pipeline_config
         )
 
         if pipeline_config_uuid is None:
             return None
 
-        trained_model.pipeline_config.pipeline_config_uuid = pipeline_config_uuid
+        trained_model.pipeline_config.uuid = pipeline_config_uuid
 
         feature_config_response = post_pipeline_feature_configs(
             pipeline_config_uuid, trained_model.pipeline_config.feature_configs
@@ -325,12 +325,12 @@ class Pipeline:  # pylint: disable=too-many-instance-attributes
         if analysis_results is None:
             return None
 
-        trained_model.trained_model_uuid = analysis_results["trainedModelMetadataUuid"]
+        trained_model.metadata_uuid = analysis_results["trainedModelMetadataUuid"]
 
         # TODO: update to use response analysisUrl once no longer broken.
         analysis_url = (
-            f"{SOTAI_API_ENDPOINT}/pipelines/{self.pipeline_uuid}"
-            f"/trained-models/{trained_model.trained_model_uuid}"
+            f"{SOTAI_API_ENDPOINT}/pipelines/{self.uuid}"
+            f"/trained-models/{trained_model.metadata_uuid}"
         )
         trained_model.analysis_url = analysis_url
 

--- a/sotai/trained_model.py
+++ b/sotai/trained_model.py
@@ -39,7 +39,7 @@ class TrainedModel(BaseModel):
     training_config: TrainingConfig = Field(...)
     training_results: TrainingResults = Field(...)
     model: CalibratedLinear = Field(...)
-    trained_model_uuid: Optional[str] = None
+    metadata_uuid: Optional[str] = None
     analysis_url: Optional[str] = None
 
     class Config:  # pylint: disable=missing-class-docstring,too-few-public-methods

--- a/sotai/types.py
+++ b/sotai/types.py
@@ -233,7 +233,7 @@ class PipelineConfig(BaseModel):
 
     Attributes:
         id: The ID of the pipeline config.
-        pipeline_config_uuid: The UUID of the pipeline.
+        uuid: The UUID of the pipeline.
         target: The column name for the target.
         target_type: The type of the target.
         primary_metric: The primary metric to use for training and evaluation.
@@ -246,7 +246,7 @@ class PipelineConfig(BaseModel):
     """
 
     id: int = Field(...)
-    pipeline_config_uuid: Optional[str] = None
+    uuid: Optional[str] = None
     target: str = Field(...)
     target_type: TargetType = Field(...)
     primary_metric: Metric = Field(...)


### PR DESCRIPTION
…e.uuid instead of pipeline.pipeline_uuid