### PR TITLE
Chore/fixing trained model api field name

### DIFF
--- a/sotai/api.py
+++ b/sotai/api.py
@@ -278,7 +278,7 @@ def post_trained_model(trained_model_path: str, trained_model_uuid: str) -> APIS
         response = requests.post(
             f"{SOTAI_BASE_URL}/{SOTAI_API_ENDPOINT}/models",
             files={"file": data_file},
-            data={"trained_model_uuid": trained_model_uuid},
+            data={"trained_model_metadata_uuid": trained_model_uuid},
             headers=get_auth_headers(),
             timeout=SOTAI_API_TIMEOUT,
         )
@@ -308,7 +308,7 @@ def post_inference(
         response = requests.post(
             f"{SOTAI_BASE_URL}/{SOTAI_API_ENDPOINT}/inferences",
             files={"file": data_file},
-            data={"trained_model_uuid": trained_model_uuid},
+            data={"trained_model_metadata_uuid": trained_model_uuid},
             headers=get_auth_headers(),
             timeout=SOTAI_API_TIMEOUT,
         )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -189,7 +189,7 @@ def test_post_trained_model(
     mock_post.assert_called_with(
         f"{SOTAI_BASE_URL}/{SOTAI_API_ENDPOINT}/models",
         files={"file": "data"},
-        data={"trained_model_uuid": "test_uuid"},
+        data={"trained_model_metadata_uuid": "test_uuid"},
         headers={"sotai-api-key": "test_api_key"},
         timeout=10,
     )
@@ -216,7 +216,7 @@ def test_post_inferencel(
     mock_post.assert_called_with(
         f"{SOTAI_BASE_URL}/{SOTAI_API_ENDPOINT}/inferences",
         files={"file": "data"},
-        data={"trained_model_uuid": "test_uuid"},
+        data={"trained_model_metadata_uuid": "test_uuid"},
         headers={"sotai-api-key": "test_api_key"},
         timeout=10,
     )


### PR DESCRIPTION
Fixing the trained_model_metadata_uuid field name that does not meet the actual API. 